### PR TITLE
Add config for networkId. Base logic on config

### DIFF
--- a/frontend/config/network_config.json
+++ b/frontend/config/network_config.json
@@ -1,0 +1,4 @@
+{
+  "dao" : "Mainnet",
+  "app" : "Testnet"
+}

--- a/frontend/config/network_id_config.json
+++ b/frontend/config/network_id_config.json
@@ -1,4 +1,4 @@
 {
-  "dao" : "Mainnet",
+  "dao" : "Testnet",
   "app" : "Testnet"
 }

--- a/frontend/config/network_id_config.json
+++ b/frontend/config/network_id_config.json
@@ -1,4 +1,4 @@
 {
-  "dao" : "Testnet",
+  "dao" : "Mainnet",
   "app" : "Testnet"
 }

--- a/frontend/src/Backend/Wallet.hs
+++ b/frontend/src/Backend/Wallet.hs
@@ -16,8 +16,6 @@ import           Data.Aeson (FromJSON, decode)
 import           GHC.Generics (Generic)
 import           Data.FileEmbed                  (embedFile)
 import qualified Data.Text as T
-import ENCOINS.Common.Events
-import Debug.Trace
 
 data WalletName
   =

--- a/frontend/src/Backend/Wallet.hs
+++ b/frontend/src/Backend/Wallet.hs
@@ -73,7 +73,7 @@ walletsSupportedInDAOMainnet = [Eternl, Flint, Gero, Nami, NuFi, Yoroi, None]
 
 -- TODO checkup list. Add or remove other
 walletsSupportedInDAOTestnet :: [WalletName]
-walletsSupportedInDAOTestnet = [Eternl, Flint, Gero, Nami, NuFi, Yoroi, None]
+walletsSupportedInDAOTestnet = [Eternl, Flint, Nami, None]
 
 walletsSupportedInDAO :: [WalletName]
 walletsSupportedInDAO = case dao networkConfig of
@@ -104,7 +104,6 @@ loadWallet eWalletName = mdo
     (\n _ -> if T.null n then Nothing else Just $ toNetworkId n)
     Testnet
     eWalletNetworkId
-  logEvent "dWalletNetworkId" $ updated dWalletNetworkId
   dWalletAddressBech32 <- elementResultJS "changeAddressBech32Element" id
   dPubKeyHash <- elementResultJS "pubKeyHashElement" id
   dStakeKeyHash <- elementResultJS "stakeKeyHashElement" id

--- a/frontend/src/ENCOINS/Common/Widgets/Advanced.hs
+++ b/frontend/src/ENCOINS/Common/Widgets/Advanced.hs
@@ -14,6 +14,8 @@ import           Reflex.Dom
 
 import           ENCOINS.Common.Widgets.Basic  (image)
 import           JS.Website                    (setElementStyle)
+import           Backend.Wallet (NetworkId)
+import           ENCOINS.Common.Utils (toText)
 
 logo :: MonadWidget t m => m ()
 logo = void $ image "logo.svg" "logo inverted" ""
@@ -48,10 +50,17 @@ noRelayNotification = elAttr "div" ("class" =: "bottom-notification" <>
   divClass "notification-content" $ text
     "All available relays are down! Try reloading the page or come back later."
 
-wrongNetworkNotification :: MonadWidget t m => Text -> m ()
-wrongNetworkNotification network = elAttr "div" ("class" =: "bottom-notification" <>
-  "id" =: "bottom-notification-network" <> "style" =: "display:none;") .
-  divClass "notification-content" $ text $ "Wrong network! Please switch to the " <> network <> "."
+wrongNetworkNotification :: MonadWidget t m => NetworkId -> m ()
+wrongNetworkNotification network = elAttr "div"
+  (  "class" =: "bottom-notification"
+  <> "id" =: "bottom-notification-network"
+  <> "style" =: "display:none;"
+  )
+  . divClass "notification-content"
+  $ text
+  $ "Wrong network! Please switch to the "
+  <> toText network
+  <> "."
 
 checkboxButton :: MonadWidget t m => m (Dynamic t Bool)
 checkboxButton = mdo

--- a/frontend/src/ENCOINS/DAO/Body.hs
+++ b/frontend/src/ENCOINS/DAO/Body.hs
@@ -4,7 +4,7 @@ import           Data.Bool                          (bool)
 import           Data.Functor                       (($>))
 import           Reflex.Dom
 
-import           Backend.Wallet                     (Wallet (..), WalletName (..), walletsSupportedInDAO)
+import           Backend.Wallet                     (Wallet (..), WalletName (..), walletsSupportedInDAO, networkConfig, NetworkConfig(..))
 import           ENCOINS.App.Widgets.Basic          (waitForScripts)
 import           ENCOINS.App.Widgets.ConnectWindow  (connectWindow)
 import           ENCOINS.Common.Widgets.Advanced    (wrongNetworkNotification)
@@ -39,7 +39,9 @@ bodyContentWidget = mdo
     pollCompletedWidget poll1
 
   wrongNetworkNotification "Mainnet"
-  let eNotificationStyleChange = bool "flex" "none" . (\w -> walletNetworkId w == "1" || walletName w == None) <$> updated dWallet
+  let eNotificationStyleChange
+        = bool "flex" "none"
+        . (\w -> walletNetworkId w == dao networkConfig || walletName w == None) <$> updated dWallet
   performEvent_ $ setElementStyle "bottom-notification-network" "display" <$> eNotificationStyleChange
 
 bodyWidget :: MonadWidget t m => m ()

--- a/frontend/src/ENCOINS/DAO/Widgets/DelegateWindow.hs
+++ b/frontend/src/ENCOINS/DAO/Widgets/DelegateWindow.hs
@@ -10,7 +10,7 @@ import           Reflex.Dom
 import           ENCOINS.App.Widgets.Basic              (elementResultJS, containerApp)
 import           ENCOINS.Common.Widgets.Advanced        (dialogWindow)
 import           ENCOINS.Common.Events (addFocusPostBuildDelayE, logEvent)
-import           Backend.Wallet (Wallet(..), toJS)
+import           Backend.Wallet (Wallet(..), toJS, lucidConfig)
 import qualified JS.DAO as JS
 import           Data.Text (Text)
 import           ENCOINS.Common.Widgets.Basic (btn, divClassId)
@@ -57,9 +57,8 @@ delegateWindow eOpen dWallet = mdo
           let dIsDisableStatus = isDisableStatus <$> dStatus
 
           let eUrl = tagPromptlyDyn dInputText btnOk
-
           performEvent_
-            $ JS.daoDelegateTx <$> attachPromptlyDyn (fmap (toJS . walletName) dWallet) eUrl
+            $ JS.daoDelegateTx lucidConfig <$> attachPromptlyDyn (fmap (toJS . walletName) dWallet) eUrl
 
           eStatus <- delegateStatus
           logEvent "Status" eStatus

--- a/frontend/src/ENCOINS/DAO/Widgets/PollWidget.hs
+++ b/frontend/src/ENCOINS/DAO/Widgets/PollWidget.hs
@@ -2,7 +2,7 @@ module ENCOINS.DAO.Widgets.PollWidget where
 
 import           Reflex.Dom
 
-import           Backend.Wallet                (Wallet (..), toJS)
+import           Backend.Wallet                (Wallet (..), toJS, lucidConfig)
 import           ENCOINS.App.Widgets.Basic     (elementResultJS)
 import           ENCOINS.Common.Utils          (toText)
 import           ENCOINS.Common.Widgets.Basic  (btn)
@@ -19,7 +19,7 @@ pollWidget (Poll n question summary answers' endTime) dWallet = do
     es <- mapM (btn "button-switching" "margin-left: 30px; margin-right: 30px; margin-bottom: 20px;" . text) answers
     let e = leftmost $ zipWith (<$) answers es
 
-    performEvent_ $ daoPollVoteTx n <$> attachPromptlyDyn (fmap (toJS . walletName) dWallet) e
+    performEvent_ $ daoPollVoteTx n lucidConfig <$> attachPromptlyDyn (fmap (toJS . walletName) dWallet) e
 
     dMsg <- elementResultJS ("elementPoll" <> toText n) id
     container "" $ divClass "app-text-normal" $ dynText dMsg

--- a/frontend/src/JS/DAO.hs
+++ b/frontend/src/JS/DAO.hs
@@ -16,17 +16,19 @@ import           Language.Javascript.JSaddle (ToJSVal(..), JSVal, JSString, text
 
 #ifdef __GHCJS__
 foreign import javascript unsafe
-  "daoPollVoteTx($1, $2, $3);"
-  daoPollVoteTx_js :: JSVal -> JSVal -> JSVal -> IO ()
+  "daoPollVoteTx($1, $2, $3, $4, $5);"
+  daoPollVoteTx_js :: JSVal -> JSVal -> JSVal -> JSVal -> JSVal -> IO ()
 
-daoPollVoteTx :: MonadIO m => Integer -> (Text, Text) -> m ()
-daoPollVoteTx n (walletName, answer) = liftIO $ do
+daoPollVoteTx :: MonadIO m => Integer -> (Text, Text) -> (Text, Text) -> m ()
+daoPollVoteTx n (apiKey, net) (walletName, answer) = liftIO $ do
   n_js          <- toJSVal $ (fromIntegral n :: Int)
+  apiKey_js     <- toJSVal apiKey
+  net_js        <- toJSVal net
   walletName_js <- toJSVal walletName
   answer_js     <- toJSVal answer
-  daoPollVoteTx_js n_js walletName_js answer_js
+  daoPollVoteTx_js n_js apiKey_js net_js walletName_js answer_js
 #else
-daoPollVoteTx :: MonadIO m => Integer -> (Text, Text) -> m ()
+daoPollVoteTx :: MonadIO m => Integer -> (Text, Text) -> (Text, Text) -> m ()
 daoPollVoteTx = const $ error "GHCJS is required!"
 #endif
 
@@ -34,16 +36,18 @@ daoPollVoteTx = const $ error "GHCJS is required!"
 
 #ifdef __GHCJS__
 foreign import javascript unsafe
-  "daoDelegateTx($1, $2);"
-  daoDelegateTx_js :: JSVal -> JSVal -> IO ()
+  "daoDelegateTx($1, $2, $3, $4);"
+  daoDelegateTx_js :: JSVal -> JSVal -> JSVal -> JSVal -> IO ()
 
-daoDelegateTx :: MonadIO m => (Text, Text) -> m ()
-daoDelegateTx (walletName, url) = liftIO $ do
+daoDelegateTx :: MonadIO m => (Text, Text) -> (Text, Text) -> m ()
+daoDelegateTx (apiKey, net) (walletName, url) = liftIO $ do
+  apiKey_js     <- toJSVal apiKey
+  net_js        <- toJSVal net
   walletName_js <- toJSVal walletName
-  url_js     <- toJSVal url
-  daoDelegateTx_js walletName_js url_js
+  url_js        <- toJSVal url
+  daoDelegateTx_js apiKey_js net_js walletName_js url_js
 #else
-daoDelegateTx :: MonadIO m => (Text, Text) -> m ()
+daoDelegateTx :: MonadIO m => (Text, Text) -> (Text, Text) -> m ()
 daoDelegateTx = const $ error "GHCJS is required!"
 #endif
 

--- a/result/js/ENCOINS.js
+++ b/result/js/ENCOINS.js
@@ -407,10 +407,10 @@ async function daoPollVoteTx(n, apiKey, net, walletName, answer)
   // loading CardanoWasm
   await loader.load();
   const CardanoWasm = loader.Cardano;
-
+  const blockfrostAddress = ["https://cardano-", net.toLowerCase(), ".blockfrost.io/api/v0"].join('');
   await lucidLoader.load();
   const lucid = await lucidLoader.Lucid.new(
-    new lucidLoader.Blockfrost("https://cardano-preprod.blockfrost.io/api/v0", apiKey),
+    new lucidLoader.Blockfrost(blockfrostAddress, apiKey),
     net,
   )
 
@@ -470,10 +470,11 @@ async function daoDelegateTx(apiKey, net, walletName, url)
   await loader.load();
   const CardanoWasm = loader.Cardano;
 
+  const blockfrostAddress = ["https://cardano-", net.toLowerCase(), ".blockfrost.io/api/v0"].join('');
   await lucidLoader.load();
   const lucid = await lucidLoader.Lucid.new(
     // TODO: check url below
-    new lucidLoader.Blockfrost("https://cardano-preprod.blockfrost.io/api/v0", apiKey),
+    new lucidLoader.Blockfrost(blockfrostAddress, apiKey),
     net,
   )
 

--- a/result/js/ENCOINS.js
+++ b/result/js/ENCOINS.js
@@ -205,6 +205,7 @@ async function walletLoad(walletName)
 
     // const rewardAddresses     = await api.getRewardAddresses();
     // setInputValue(rewardAddressesElement, rewardAddresses);
+    setInputValue("EndWalletLoad", "");
     console.log("end walletLoad");
   } catch (e) {
     console.log(e.message);

--- a/result/js/ENCOINS.js
+++ b/result/js/ENCOINS.js
@@ -401,7 +401,7 @@ function toUTF8Array(str) {
   return utf8;
 }
 
-async function daoPollVoteTx(n, walletName, answer)
+async function daoPollVoteTx(n, apiKey, net, walletName, answer)
 {
   // loading CardanoWasm
   await loader.load();
@@ -409,8 +409,8 @@ async function daoPollVoteTx(n, walletName, answer)
 
   await lucidLoader.load();
   const lucid = await lucidLoader.Lucid.new(
-    new lucidLoader.Blockfrost("https://cardano-mainnet.blockfrost.io/api/v0", "mainnetK4sRBCTDwqzK1KRuFxnpuxPbKF4ZQrnl"),
-    "Mainnet",
+    new lucidLoader.Blockfrost("https://cardano-preprod.blockfrost.io/api/v0", apiKey),
+    net,
   )
 
   try {
@@ -463,7 +463,7 @@ async function daoPollVoteTx(n, walletName, answer)
   }
 };
 
-async function daoDelegateTx(walletName, url)
+async function daoDelegateTx(apiKey, net, walletName, url)
 {
   // loading CardanoWasm
   await loader.load();
@@ -472,8 +472,8 @@ async function daoDelegateTx(walletName, url)
   await lucidLoader.load();
   const lucid = await lucidLoader.Lucid.new(
     // TODO: check url below
-    new lucidLoader.Blockfrost("https://cardano-mainnet.blockfrost.io/api/v0", "mainnetK4sRBCTDwqzK1KRuFxnpuxPbKF4ZQrnl"),
-    "Mainnet",
+    new lucidLoader.Blockfrost("https://cardano-preprod.blockfrost.io/api/v0", apiKey),
+    net,
   )
 
   try {


### PR DESCRIPTION
Resolve #15 

Test wallets on dao and delegate in new modes.

**Dao preprod mode**: 
1. **Navi** 
    - [x] dao
    - [x] delegate
2. **Flint** 
    - [x] dao
    - [x] delegate
3. **Lace** wasn't added. It stopped to connect after first successful dao transaction and started to complain about datum format. 
```
INVALID_DATUM (Only one type of datum can be specified for a given output but both Datum hash and inline Datum were provided)
```
- [x] 4. Make logic of `wrongNetworkNotification` respective. 
