### PR TITLE
Personal mark of delegated coins

### DIFF
--- a/frontend/src/Backend/Servant/Client.hs
+++ b/frontend/src/Backend/Servant/Client.hs
@@ -23,7 +23,7 @@ type API =   "newTx"        :> ReqBody '[JSON] (InputOfEncoinsApi, TransactionIn
         :<|> "servers"      :> Get '[JSON] (Map Text Integer)
         :<|> "current"      :> Get '[JSON] [Text]
         :<|> "info"         :> ReqBody '[JSON] Address
-                            :> Get '[JSON] (Text, Integer)
+                            :> Post '[JSON] (Text, Integer)
 
 type RespEvent t a      = Event t (ReqResult () a)
 type Res t m res        = Event t () -> m (RespEvent t res)

--- a/frontend/src/Backend/Servant/Client.hs
+++ b/frontend/src/Backend/Servant/Client.hs
@@ -22,6 +22,8 @@ type API =   "newTx"        :> ReqBody '[JSON] (InputOfEncoinsApi, TransactionIn
         :<|> "version"      :> Get '[JSON] ServerVersion
         :<|> "servers"      :> Get '[JSON] (Map Text Integer)
         :<|> "current"      :> Get '[JSON] [Text]
+        :<|> "info"         :> ReqBody '[JSON] Address
+                            :> Get '[JSON] (Text, Integer)
 
 type RespEvent t a      = Event t (ReqResult () a)
 type Res t m res        = Event t () -> m (RespEvent t res)
@@ -37,6 +39,7 @@ data ApiClient t m = ApiClient
   , versionRequest         :: Res t m ServerVersion
   , serversRequest         :: Res t m (Map Text Integer)
   , currentRequest         :: Res t m [Text]
+  , infoRequest            :: ReqRes t m Address (Text, Integer)
   }
 
 mkApiClient :: forall t m . MonadWidget t m => BaseUrl -> ApiClient t m
@@ -49,4 +52,5 @@ mkApiClient host = ApiClient{..}
       statusRequest :<|>
       versionRequest :<|>
       serversRequest :<|>
-      currentRequest) = client (Proxy @API) (Proxy @m) (Proxy @()) (pure host)
+      currentRequest :<|>
+      infoRequest) = client (Proxy @API) (Proxy @m) (Proxy @()) (pure host)

--- a/frontend/src/Backend/Servant/Requests.hs
+++ b/frontend/src/Backend/Servant/Requests.hs
@@ -120,6 +120,19 @@ currentRequestWrapper baseUrl e = do
   logEvent "current servers request" eRespUnwrapped
   return eRespUnwrapped
 
+-- Fetch how much encoins and which relay the particular wallet delegated.
+infoRequestWrapper :: MonadWidget t m
+  => BaseUrl
+  -> Dynamic t Address
+  -> Event t ()
+  -> m (Event t (Either Int (Text, Integer)))
+infoRequestWrapper baseUrl addr e = do
+  let ApiClient{..} = mkApiClient baseUrl
+  eResp <- infoRequest (Right <$> addr) e
+  let eRespUnwrapped = mkStatusOrResponse <$> eResp
+  logEvent "info request" eRespUnwrapped
+  return eRespUnwrapped
+
 ---------------------------------------------- Utilities ----------------------------------------
 
 urls :: [Text]

--- a/frontend/src/Backend/Utility.hs
+++ b/frontend/src/Backend/Utility.hs
@@ -11,8 +11,10 @@ import qualified Data.Text     as T
 import           Reflex.Dom
 
 normalizePingUrl :: Text -> Text
-normalizePingUrl t = T.append (T.dropWhileEnd (== '/') t) $ case appNetwork of
-  Mainnet -> "//"
+normalizePingUrl url = T.append (T.dropWhileEnd (== '/') url) $ case appNetwork of
+  Mainnet -> if T.isInfixOf url "execute-api.eu-central-1.amazonaws.com"
+    then "//"
+    else "/"
   Testnet -> "/"
 
 toEither :: e -> Maybe a -> Either e a

--- a/frontend/src/ENCOINS/DAO/Widgets/DelegateWindow.hs
+++ b/frontend/src/ENCOINS/DAO/Widgets/DelegateWindow.hs
@@ -21,7 +21,7 @@ import           ENCOINS.Common.Utils            (checkUrl, toText)
 import           ENCOINS.Common.Widgets.Advanced (dialogWindow)
 import           ENCOINS.Common.Widgets.Basic    (btn, btnWithBlock, divClassId)
 import           ENCOINS.DAO.Widgets.RelayTable  (fetchRelayTable,
-                                                  relayAmountWidget)
+                                                  relayAmountWidget, fetchDelegatedByAddress)
 import qualified JS.DAO                          as JS
 
 
@@ -31,41 +31,44 @@ delegateWindow :: MonadWidget t m
   -> m ()
 delegateWindow eOpen dWallet = mdo
   eDelay <- delay 0.05 eOpen
-  relays <- fetchRelayTable eDelay
+  eeRelays <- fetchRelayTable eDelay
+  emDelegated <- fetchDelegatedByAddress (walletChangeAddress <$> dWallet) eDelay
   eUrlOk <- dialogWindow
     True
     eOpen
     (leftmost [void eUrlOk])
-    "width: min(90%, 950px); padding-left: min(5%, 70px); padding-right: min(5%, 70px); padding-top: min(5%, 30px); padding-bottom: min(5%, 30px);"
+    delegateWindowStyle
     "Delegate ENCS" $ mdo
-          eUrlTable <- relayAmountWidget relays
-          divClass "dao-DelegateWindow_EnterUrl" $ text "Enter relay url:"
+      eUrlTable <- relayAmountWidget eeRelays emDelegated
+      divClass "dao-DelegateWindow_EnterUrl" $ text "Choose relay URL above or enter new one below:"
 
-          dInputText <- inputWidget eOpen
-          let eInputText = updated dInputText
+      dInputText <- inputWidget eOpen
+      let eInputText = updated dInputText
 
-          let eNonEmptyUrl = ffilter (not . T.null) eInputText
-          let eEmptyUrl = ffilter T.null eInputText
-          let eUrlStatus = leftmost
-                [
-                  UrlEmpty   <$ eEmptyUrl
-                -- Check url when it is ONLY not empty
-                , bool UrlInvalid UrlValid . checkUrl <$> eNonEmptyUrl
-                ]
+      let eNonEmptyUrl = ffilter (not . T.null) eInputText
+      let eEmptyUrl = ffilter T.null eInputText
+      let eUrlStatus = leftmost
+            [
+              UrlEmpty   <$ eEmptyUrl
+            -- Check url when it is ONLY not empty
+            , bool UrlInvalid UrlValid . checkUrl <$> eNonEmptyUrl
+            ]
 
-          dIsInvalidUrl <- holdDyn UrlEmpty eUrlStatus
-          (eStake, eUnstake) <- stakingButtonWidget dIsInvalidUrl
+      dIsInvalidUrl <- holdDyn UrlEmpty eUrlStatus
+      (eStake, eUnstake) <- stakingButtonWidget dIsInvalidUrl
 
-          let eUrlStake = tagPromptlyDyn dInputText eStake
-          let eUrlUnstake = "https://encoins.io" <$ eUnstake
-          let eUrl = leftmost [eUrlTable, eUrlStake, eUrlUnstake]
-          let LucidConfig apiKey networkId policyId assetName = lucidConfigDao
-          performEvent_ $
-            JS.daoDelegateTx apiKey networkId policyId assetName
-            <$> attachPromptlyDyn (fmap (toJS . walletName) dWallet) eUrl
-
-          return eUrl
+      let eUrlStake = tagPromptlyDyn dInputText eStake
+      let eUrlUnstake = "https://encoins.io" <$ eUnstake
+      let eUrl = leftmost [eUrlTable, eUrlStake, eUrlUnstake]
+      let LucidConfig apiKey networkId policyId assetName = lucidConfigDao
+      performEvent_ $
+        JS.daoDelegateTx apiKey networkId policyId assetName
+        <$> attachPromptlyDyn (fmap (toJS . walletName) dWallet) eUrl
+      return eUrl
   pure ()
+
+delegateWindowStyle :: Text
+delegateWindowStyle = "width: min(90%, 950px); padding-left: min(5%, 70px); padding-right: min(5%, 70px); padding-top: min(5%, 30px); padding-bottom: min(5%, 30px);"
 
 inputWidget :: MonadWidget t m
   => Event t ()

--- a/frontend/src/ENCOINS/DAO/Widgets/DelegateWindow.hs
+++ b/frontend/src/ENCOINS/DAO/Widgets/DelegateWindow.hs
@@ -50,7 +50,7 @@ delegateWindow eOpen dWallet = mdo
       let eUrlStatus = leftmost
             [
               UrlEmpty   <$ eEmptyUrl
-            -- Check url when it is ONLY not empty
+            -- Check url ONLY when it is not empty
             , bool UrlInvalid UrlValid . checkUrl <$> eNonEmptyUrl
             ]
 

--- a/frontend/src/ENCOINS/DAO/Widgets/DelegateWindow.hs
+++ b/frontend/src/ENCOINS/DAO/Widgets/DelegateWindow.hs
@@ -20,8 +20,9 @@ import           ENCOINS.Common.Events
 import           ENCOINS.Common.Utils            (checkUrl, toText)
 import           ENCOINS.Common.Widgets.Advanced (dialogWindow)
 import           ENCOINS.Common.Widgets.Basic    (btn, btnWithBlock, divClassId)
-import           ENCOINS.DAO.Widgets.RelayTable  (fetchRelayTable,
-                                                  relayAmountWidget, fetchDelegatedByAddress)
+import           ENCOINS.DAO.Widgets.RelayTable  (fetchDelegatedByAddress,
+                                                  fetchRelayTable,
+                                                  relayAmountWidget, unStakeUrl)
 import qualified JS.DAO                          as JS
 
 
@@ -58,7 +59,7 @@ delegateWindow eOpen dWallet = mdo
       (eStake, eUnstake) <- stakingButtonWidget dIsInvalidUrl
 
       let eUrlStake = tagPromptlyDyn dInputText eStake
-      let eUrlUnstake = "https://encoins.io" <$ eUnstake
+      let eUrlUnstake = unStakeUrl <$ eUnstake
       let eUrl = leftmost [eUrlTable, eUrlStake, eUrlUnstake]
       let LucidConfig apiKey networkId policyId assetName = lucidConfigDao
       performEvent_ $

--- a/frontend/src/ENCOINS/DAO/Widgets/RelayTable.hs
+++ b/frontend/src/ENCOINS/DAO/Widgets/RelayTable.hs
@@ -6,9 +6,11 @@ module ENCOINS.DAO.Widgets.RelayTable
   (
     relayAmountWidget
   , fetchRelayTable
+  , fetchDelegatedByAddress
   ) where
 
 import           Control.Monad                                 (forM)
+import           Data.Bool                                     (bool)
 import           Data.List                                     (sortOn)
 import qualified Data.Map                                      as Map
 import           Data.Maybe                                    (fromMaybe)
@@ -16,6 +18,7 @@ import           Data.Ord                                      (Down (..))
 import           Data.Text                                     (Text)
 import           Reflex.Dom
 
+import           Backend.Protocol.Types
 import           Backend.Servant.Requests                      (serversRequestWrapper)
 import           Backend.Utility                               (switchHoldDyn)
 import           Config.Config                                 (delegateServerUrl)
@@ -26,9 +29,11 @@ import           ENCOINS.DAO.Widgets.DelegateWindow.RelayNames (relayNames)
 
 relayAmountWidget :: MonadWidget t m
   => Event t (Either Int [(Text, Integer)])
+  -> Event t (Maybe (Text, Integer))
   -> m (Event t Text)
-relayAmountWidget eeRelays = do
+relayAmountWidget eeRelays emDelegated = do
   deRelays <- holdDyn (Right []) eeRelays
+  dmDelegated <- holdDyn Nothing emDelegated
   switchHoldDyn deRelays $ \case
     Left err -> do
       article $
@@ -36,13 +41,12 @@ relayAmountWidget eeRelays = do
       pure never
     Right relays -> article $ table $ do
       el "thead" $ tr $
-        mapM_ (\h -> th $ text h) ["Relay", "Delegated", ""]
+        mapM_ (\h -> th $ text h) ["Relay", "Total", "Delegated", ""]
       el "tbody" $ do
         evs <- forM relays $ \(relay, amount) -> tr $ do
           tdRelay $ text $ fromMaybe relay (relay `Map.lookup` relayNames)
-          tdAmount
-            $ text
-            $ toText (floor @Double $ fromIntegral amount / 1000000 :: Integer) <> " ENCS"
+          tdAmount $ text $ mkAmount amount
+          tdAmount $ dynText $ mkDelegated relay <$> dmDelegated
           eClick <- tdButton $ btn "button-switching inverted" "" $ text "Delegate"
           pure $ relay <$ eClick
         pure $ leftmost evs
@@ -54,6 +58,29 @@ relayAmountWidget eeRelays = do
     tdRelay = elAttr "td" ("class" =: "dao-DelegateWindow_TableRelay")
     tdAmount = elAttr "td" ("class" =: "dao-DelegateWindow_TableAmount")
     tdButton = elAttr "td" ("class" =: "dao-DelegateWindow_TableButton")
+
+fetchRelayTable :: MonadWidget t m
+  => Event t ()
+  -> m (Event t (Either Int [(Text, Integer)]))
+fetchRelayTable eOpen = do
+  eServers <- serversRequestWrapper delegateServerUrl eOpen
+  let eeRes = fmap (sortOn (Down . snd) . Map.toList) <$> eServers
+  pure eeRes
+
+fetchDelegatedByAddress :: MonadWidget t m
+  => Dynamic t Address
+  -> Event t ()
+  -> m (Event t (Maybe (Text, Integer)))
+fetchDelegatedByAddress dAddr eFire = do
+  pure $ Just ("https://encoins.io", 1000000) <$ eFire
+
+mkAmount :: Integer -> Text
+mkAmount amount =
+  toText (floor @Double $ fromIntegral amount / 1000000 :: Integer) <> " ENCS"
+
+mkDelegated :: Text -> Maybe (Text, Integer) -> Text
+mkDelegated relay =
+  maybe "" (\(r,n) -> bool "" (mkAmount n) (r == relay))
 
 -- sortRelayAmounts :: Maybe (Map Text String) -> [(Text, Integer)]
 -- sortRelayAmounts =
@@ -68,11 +95,3 @@ relayAmountWidget eeRelays = do
 -- fetchRelayTable eOpen = do
 --   let eUrl = "https://encoins.io/delegations.json" <$ eOpen
 --   fmap sortRelayAmounts <$> getAndDecode eUrl
-
-fetchRelayTable :: MonadWidget t m
-  => Event t ()
-  -> m (Event t (Either Int [(Text, Integer)]))
-fetchRelayTable eOpen = do
-  eServers <- serversRequestWrapper delegateServerUrl eOpen
-  let eeRes = fmap (sortOn (Down . snd) . Map.toList) <$> eServers
-  pure eeRes

--- a/frontend/src/ENCOINS/DAO/Widgets/RelayTable.hs
+++ b/frontend/src/ENCOINS/DAO/Widgets/RelayTable.hs
@@ -20,7 +20,8 @@ import           Data.Text                                     (Text)
 import           Reflex.Dom
 
 import           Backend.Protocol.Types
-import           Backend.Servant.Requests                      (serversRequestWrapper)
+import           Backend.Servant.Requests                      (infoRequestWrapper,
+                                                                serversRequestWrapper)
 import           Backend.Utility                               (switchHoldDyn)
 import           Config.Config                                 (delegateServerUrl)
 import           ENCOINS.Common.Events
@@ -80,8 +81,9 @@ fetchDelegatedByAddress :: MonadWidget t m
   -> Event t ()
   -> m (Event t (Maybe (Text, Integer)))
 fetchDelegatedByAddress dAddr eFire = do
-  -- TODO: Update when 4th endpoint is done
-  pure $ Just (unStakeUrl, 1000000) <$ eFire
+  eeInfo <- infoRequestWrapper delegateServerUrl dAddr eFire
+  let meInfo = either (const Nothing) Just <$> eeInfo
+  pure meInfo
 
 mkAmount :: Integer -> Text
 mkAmount amount =
@@ -93,7 +95,7 @@ mkDelegateButton relay =
 
 isDelegated :: Text -> Maybe (Text, Integer) -> Bool
 isDelegated relay = \case
-  Nothing -> False
+  Nothing    -> False
   Just (r,_) -> r == relay
 
 unStakeUrl :: Text

--- a/result/css/encoins.webflow.css
+++ b/result/css/encoins.webflow.css
@@ -1780,6 +1780,8 @@ body {
   gap: 10px;
   margin-left: 5%;
   margin-right: 5%;
+  padding-left: 1em;
+  padding-right: 1em;
 }
 
 @media screen and (min-width: 767px) {


### PR DESCRIPTION
Resolve #113 

![image](https://github.com/encryptedcoins/encoins-frontend/assets/28530747/b8584893-610f-453d-ab16-0bb62c53d06f)

Now, the title of delegate button is changing to amount of delegated coins with respect to the current wallet and turns to inactive. Otherwise it stays "Delegate" and active.